### PR TITLE
Add `amazon.ae` domain

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -18,7 +18,8 @@ const AMAZON_NATIONAL_DOMAINS = [
   "amazon.ca",
   "amazon.com.mx",
   "amazon.com.au",
-  "amazon.com.br"
+  "amazon.com.br",
+  "amazon.ae"
 ];
 
 const AMAZON_TLD_DOMAINS = [


### PR DESCRIPTION
Adds `amazon.ae` domain for the United Arab Emirates market, which launched in May 2019.

Let me know if there's anything else I need to do for this pull request.