### PR TITLE
Added .sg and .se TLDs

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -21,7 +21,9 @@ const AMAZON_NATIONAL_DOMAINS = [
   "amazon.com.mx",
   "amazon.com.au",
   "amazon.com.br",
-  "amazon.ae"
+  "amazon.ae",
+  "amazon.se",
+  "amazon.sg"
 ];
 
 const AMAZON_TLD_DOMAINS = [


### PR DESCRIPTION
Added Swedish (#14) and Singaporean (#7) versions of Amazon to the filter since they were requested, and I wanted one for myself.