### PR TITLE
Add all of the current domains to the lists

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -85,7 +85,8 @@ const AMAZON_SERVICES_DOMAINS = [
   "awsevents.com",
   "primevideo.com",
   "twitch.com",
-  "twitch.tv"
+  "twitch.tv",
+  "ext-twitch.tv"
 ];
 
 let AMAZON_DOMAINS = [

--- a/src/background.js
+++ b/src/background.js
@@ -22,7 +22,8 @@ const AMAZON_NATIONAL_DOMAINS = [
   "amazon.com.au",
   "amazon.com.br",
   "amazon.ae",
-  "amazon.se"
+  "amazon.se",
+  "amazon.sg"
 ];
 
 const AMAZON_TLD_DOMAINS = [

--- a/src/background.js
+++ b/src/background.js
@@ -25,7 +25,8 @@ const AMAZON_NATIONAL_DOMAINS = [
   "amazon.se",
   "amazon.sg",
   "amazon.com.be",
-  "amazon.eg"
+  "amazon.eg",
+  "amazon.pl"
 ];
 
 const AMAZON_TLD_DOMAINS = [

--- a/src/background.js
+++ b/src/background.js
@@ -26,7 +26,8 @@ const AMAZON_NATIONAL_DOMAINS = [
   "amazon.sg",
   "amazon.com.be",
   "amazon.eg",
-  "amazon.pl"
+  "amazon.pl",
+  "amazon.sa"
 ];
 
 const AMAZON_TLD_DOMAINS = [

--- a/src/background.js
+++ b/src/background.js
@@ -21,7 +21,8 @@ const AMAZON_NATIONAL_DOMAINS = [
   "amazon.com.mx",
   "amazon.com.au",
   "amazon.com.br",
-  "amazon.ae"
+  "amazon.ae",
+  "amazon.se"
 ];
 
 const AMAZON_TLD_DOMAINS = [

--- a/src/background.js
+++ b/src/background.js
@@ -24,7 +24,8 @@ const AMAZON_NATIONAL_DOMAINS = [
   "amazon.ae",
   "amazon.se",
   "amazon.sg",
-  "amazon.com.be"
+  "amazon.com.be",
+  "amazon.eg"
 ];
 
 const AMAZON_TLD_DOMAINS = [

--- a/src/background.js
+++ b/src/background.js
@@ -23,7 +23,8 @@ const AMAZON_NATIONAL_DOMAINS = [
   "amazon.com.br",
   "amazon.ae",
   "amazon.se",
-  "amazon.sg"
+  "amazon.sg",
+  "amazon.com.be"
 ];
 
 const AMAZON_TLD_DOMAINS = [


### PR DESCRIPTION
Adds the following domains:
- Belgium ([.com.be](https://amazon.com.be/))
- Egypt ([.eg](https://amazon.eg/))
- Poland ([.pl](https://amazon.pl/))
- Saudi Arabia ([.sa](https://amazon.sa/))
- Singapore ([.sg](https://amazon.sg/))
- Sweden ([.se](https://amazon.se/))

Also adds the twitch.tv extension domain ([ext-twitch.tv](https://ext-twitch.tv/))